### PR TITLE
Comments and documentation typos fix

### DIFF
--- a/examples/ent-chains.py
+++ b/examples/ent-chains.py
@@ -51,9 +51,9 @@ def chain_search(source_entropy,target):
             percentage = (float(100) / len(source_entropy)) * x
             print "\rFinding chains... {}%".format(percentage),
         if source_entropy[x]:
-            #contiune chain or start new chain
+            #continue chain or start new chain
             if cur_len > -1:
-                #contiune chain
+                #continue chain
                 cur_len += 1
             else:
                 #start new chain
@@ -67,7 +67,7 @@ def chain_search(source_entropy,target):
                 if cur_len >= target:
                     #append current chain to list
                     chains.append([cur_start,cur_len])
-                #reset chaiin stats
+                #reset chain stats
                 cur_start = -1
                 cur_len = -1
             else:

--- a/examples/hunt.md
+++ b/examples/hunt.md
@@ -46,7 +46,7 @@ Running hunt
 For this example hunt is called with the following command:
 
 ```
-hunt example.001 password –chain=256
+hunt example.001 password --chain=256
 ```
 
 The options are as follows:
@@ -220,7 +220,7 @@ Looking at the FAT volume we can map out the layout of the files. The layout of 
 
 We can now use hunt to try and locate some headers. hunt is called in exactly the same way as before:
 ```
-hunt example2.001 password –chain=256
+hunt example2.001 password --chain=256
 ```
 
 In this instance, only one header was located at sector 20496.

--- a/examples/hunt.py
+++ b/examples/hunt.py
@@ -103,9 +103,9 @@ def chain_search(source_entropy,target):
             percentage = (float(100) / len(source_entropy)) * x
             print "\rFinding chains... {}%".format(percentage),
         if source_entropy[x]:
-            #contiune chain or start new chain
+            #continue chain or start new chain
             if cur_len > -1:
-                #contiune chain
+                #continue chain
                 cur_len += 1
             else:
                 #start new chain
@@ -119,7 +119,7 @@ def chain_search(source_entropy,target):
                 if cur_len >= target:
                     #append current chain to list
                     chains.append([cur_start,cur_len])
-                #reset chaiin stats
+                #reset chain stats
                 cur_start = -1
                 cur_len = -1
             else:
@@ -150,7 +150,7 @@ def test_chains(chains,f,hash_options,crypto_options,passwords):
 
         #calc start location, searching for the typical location of a normal
         #backup header and not a hidden header. Changing the -256 will change
-        #this or increasing the search size will aloow it to be found however
+        #this or increasing the search size will allow it to be found however
         #this will be slow
         search_start = (chain_sector + chain_len - 256 - search_size) * 512
         search_end = (chain_sector + chain_len - 256 + search_size) * 512


### PR DESCRIPTION
Like in the subject. Moreover, some of them was unclear.
For example, `–chain=256` was unclear, because it could be `--chain=256` or `-chain=256`.